### PR TITLE
Fix config-itop init in kubernetes

### DIFF
--- a/helm-chart/templates/configmap.yaml
+++ b/helm-chart/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name:  config-{{ .Release.Name }}
+data:
+  config-itop.php: |
+    <?php
+    $MySettings = array(
+            'db_host'    => $_ENV['DB_HOSTNAME'],
+            'db_name'    => $_ENV['DB_ENV_MYSQL_DATABASE'],
+            'db_user'    => $_ENV['DB_ENV_MYSQL_USER'],
+            'db_pwd'     => $_ENV['DB_ENV_MYSQL_PASSWORD'],
+            'db_subname' => $_ENV['DB_PREFIX'],
+    );
+    
+    $MyModuleSettings = array();
+    $MyModules = array('addons' => array());

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -32,7 +32,10 @@ spec:
       securityContext:
         fsGroup: 33
       volumes:
-        - name: itop-conf-pv
+        - name: itop-conf-php
+          configMap:
+            name: config-{{ .Release.Name }}
+        - name: itop-conf-pvc
           persistentVolumeClaim:
             claimName: itop-conf-pvc
         - name: itop-data-pv
@@ -58,7 +61,9 @@ spec:
             - mountPath: "/var/www/html/log"
               name: itop-log-pv
             - mountPath: "/var/www/html/conf"
-              name: itop-conf-pv
+              name: itop-conf-pvc
+            - mountPath: "/var/www/html/config_php"
+              name: itop-conf-php
           env:
             - name: "DB_ENV_MYSQL_DATABASE"
               value: {{ .Values.environment.db_name}}
@@ -76,12 +81,23 @@ spec:
             httpGet:
               path: /webservices/status.php
               port: http
+            failureThreshold: 20
           readinessProbe:
             httpGet:
               path: /webservices/status.php
               port: http
+            failureThreshold: 20
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      initContainers:
+      - name: init-config
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        volumeMounts:
+        - mountPath: "/var/www/html/conf"
+          name: itop-conf-pvc
+        - mountPath: "/var/www/html/config_php"
+          name: itop-conf-php
+        command: ['sh','-c','mkdir conf/production && cp config_php/config-itop.php conf/production/ && chmod 660 conf/production/config-itop.php']
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: itop-conf-php
           configMap:
             name: config-{{ .Release.Name }}
-        - name: itop-conf-pvc
+        - name: itop-conf-pv
           persistentVolumeClaim:
             claimName: itop-conf-pvc
         - name: itop-data-pv
@@ -61,7 +61,7 @@ spec:
             - mountPath: "/var/www/html/log"
               name: itop-log-pv
             - mountPath: "/var/www/html/conf"
-              name: itop-conf-pvc
+              name: itop-conf-pv
             - mountPath: "/var/www/html/config_php"
               name: itop-conf-php
           env:

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -81,12 +81,10 @@ spec:
             httpGet:
               path: /webservices/status.php
               port: http
-            failureThreshold: 20
           readinessProbe:
             httpGet:
               path: /webservices/status.php
               port: http
-            failureThreshold: 20
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       initContainers:
@@ -97,7 +95,7 @@ spec:
           name: itop-conf-pvc
         - mountPath: "/var/www/html/config_php"
           name: itop-conf-php
-        command: ['sh','-c','[ -f /var/www/html/conf/production ] && mkdir conf/production && cp config_php/config-itop.php conf/production/ && chmod 660 conf/production/config-itop.php']
+        command: ['sh','-c','if test -f /var/www/html/conf/production/config-itop.php; then exit 0; else mkdir conf/production && cp config_php/config-itop.php conf/production/ && chmod 660 conf/production/config-itop.php; fi' ]
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -97,7 +97,7 @@ spec:
           name: itop-conf-pvc
         - mountPath: "/var/www/html/config_php"
           name: itop-conf-php
-        command: ['sh','-c','mkdir conf/production && cp config_php/config-itop.php conf/production/ && chmod 660 conf/production/config-itop.php']
+        command: ['sh','-c','[ -f /var/www/html/conf/production ] && mkdir conf/production && cp config_php/config-itop.php conf/production/ && chmod 660 conf/production/config-itop.php']
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: supervisions/itop
   pullPolicy: Always
-  tag: 3.0
+  tag: "3.0"
 
 environment:
   db_host: <mysql-server-url> "mysql-chart.database.svc.cluster.local"


### PR DESCRIPTION
Hello,

Like I said in my last PR, I'm back with new PR ! 

You load the config-itop.php in docker image but kubernetes overwrite this file because it mount an empty directory at le volume mount target. 

So the`webservices/status.php` send `Error 500` due to config-itop.php missing. 

We have to load the config file in config map, mount the config map in container. And start an init container to test the presence, copy the config file on right directory and adjust right to make config file writable for the setup.


