### PR TITLE
Improvement of helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ Essential/files/iTop-essential-docker.tar.gz
 # ignore iTop Professional source and builds
 Professional/files/iTop Professional-*.zip
 Professional/files/iTop-professional-docker.tar.gz
+
+# ignore helm build`s artifacts
+helm-chart/charts
+helm-chart/Chart.lock

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: itop-chart
-description: Itop Helm chart 
+description: Itop Helm chart
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,10 +15,16 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.0.0"
+appVersion: "3.1.0"
+
+dependencies:
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: https://charts.bitnami.com/bitnami
+    version: 14.1.4

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -10,17 +10,9 @@ You can check the [template](./templates/pvc.yaml) for more info.
 
 The folders that are saved are specified in the [deployment.yaml](./templates/deployment.yaml) file :
 
-```yaml
-volumeMounts:
-  - mountPath: "/var/www/html/data"
-    name: itop-data-pv
-  - mountPath: "/var/www/html/env-production"
-    name: itop-env-pv
-  - mountPath: "/var/www/html/log"
-    name: itop-log-pv
-  - mountPath: "/var/www/html/conf"
-    name: itop-conf-pv
-```
+conf, data, env-production, log, extensions, web.
+
+Chart support using separate PV for each folder, or it can be used one PV ( pvc.useOnePV: true ).
 
 ## Values.yaml
 
@@ -62,6 +54,31 @@ You can create a configmap and add it to the pod deployment in order to have the
 
 This is not recommended.
 
-## What is not added
+## Installation
 
-A MySQL/MariaDB chart link in order to also have a db deployed to go with the iTop instance.
+if it is installation from scratch, it is necessary to disable all probes in pod,
+because probes can be failed while install:
+
+```yaml
+startupProbe:
+  enabled: false
+
+readinessProbe:
+  enabled: false
+
+livenessProbe:
+  enabled: false
+```
+
+and after deploying release, open browser at <your_itop_url>/setup
+and follow the installation steps.
+
+After installation will be finished, probes can be enabled.
+
+## Upgrade
+
+- disable POD's probes
+
+- deploy release with newer tag
+
+- open browser at <your_itop_url>/setup and follow for upgrade wizard

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -29,9 +29,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "itop-chart.serviceAccountName" . }}
-      securityContext:
-        fsGroup: 33
+      securityContext: {{- .Values.podSecurityContext | toYaml | nindent 8 }}
+      {{- if .Values.pvc.enabled }}
       volumes:
+      {{- if .Values.pvc.useOnePV }}
+        - name: itop-pv
+          persistentVolumeClaim:
+            claimName: itop-pv
+      {{- else }}
         - name: itop-conf-pv
           persistentVolumeClaim:
             claimName: itop-conf-pvc
@@ -43,22 +48,36 @@ spec:
             claimName: itop-env-pvc
         - name: itop-log-pv
           persistentVolumeClaim:
-            claimName: itop-log-pvc   
+            claimName: itop-log-pvc
+        - name: itop-extensions-pv
+          persistentVolumeClaim:
+            claimName: itop-extensions-pvc
+      {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.pvc.enabled }}
           volumeMounts:
             - mountPath: "/var/www/html/data"
-              name: itop-data-pv
+              name: {{ ternary "itop-pv" "itop-data-pv" .Values.pvc.useOnePV }}
+              subPath: {{ ternary "data" "" .Values.pvc.useOnePV }}
             - mountPath: "/var/www/html/env-production"
-              name: itop-env-pv
+              name: {{ ternary "itop-pv" "itop-env-pv" .Values.pvc.useOnePV }}
+              subPath: {{ ternary "env-production" "" .Values.pvc.useOnePV }}
             - mountPath: "/var/www/html/log"
-              name: itop-log-pv
+              name: {{ ternary "itop-pv" "itop-log-pv" .Values.pvc.useOnePV }}
+              subPath: {{ ternary "log" "" .Values.pvc.useOnePV }}
             - mountPath: "/var/www/html/conf"
-              name: itop-conf-pv
+              name: {{ ternary "itop-pv" "itop-conf-pv" .Values.pvc.useOnePV }}
+              subPath: {{ ternary "conf" "" .Values.pvc.useOnePV }}
+            - mountPath: "/var/www/html/extensions"
+              name: {{ ternary "itop-pv" "itop-extensions-pv" .Values.pvc.useOnePV }}
+              subPath: {{ ternary "extensions" "" .Values.pvc.useOnePV }}
+          {{- end }}
           env:
             - name: "DB_ENV_MYSQL_DATABASE"
               value: {{ .Values.environment.db_name}}
@@ -68,20 +87,56 @@ spec:
               value: {{ .Values.environment.db_user}}
             - name: "DB_ENV_MYSQL_PASSWORD"
               value: {{ .Values.environment.db_pwd}}
+            - name: "DB_PREFIX"
+              value: {{ .Values.environment.db_prefix}}
           ports:
             - name: http
               containerPort: {{ .Values.container.port }}
               protocol: TCP
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /webservices/status.php
+              port: http
+          {{- .Values.startupProbe | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /webservices/status.php
               port: http
+          {{- .Values.livenessProbe | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /webservices/status.php
               port: http
+          {{- .Values.readinessProbe | toYaml | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if and .Values.pvc.enabled .Values.mariadb.enabled }}
+      initContainers:
+        - name: init-config
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - 'bash'
+            - '-c'
+            - |
+              cd /var/www/html
+              if [ ! -e "confPV/production/config-itop.php" ];then
+                mkdir -p confPV/production
+                cp conf/production/config-itop.php confPV/production/
+                chown 33 confPV/production/config-itop.php
+              fi
+              exit 0
+          volumeMounts:
+            - mountPath: "/var/www/html/confPV"
+              name: {{ ternary "itop-pv" "itop-conf-pv" .Values.pvc.useOnePV }}
+              subPath: {{ ternary "conf" "" .Values.pvc.useOnePV }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/templates/pvc.yaml
+++ b/helm-chart/templates/pvc.yaml
@@ -1,11 +1,31 @@
+{{- if .Values.pvc.enabled }}
+{{- if .Values.pvc.useOnePV }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: itop-pv
+  annotations: {{- .Values.pvc.commonAnnotations | toYaml | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.pvc.accessMode }}
+  {{- if  .Values.pvc.storageClassName }}
+  storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.pvc.data.size }}
+{{- else }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: itop-conf-pvc
+  annotations: {{- .Values.pvc.commonAnnotations | toYaml | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.pvc.accessMode }}
+  {{- if  .Values.pvc.storageClassName }}
   storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.pvc.conf.size }}
@@ -14,10 +34,13 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: itop-data-pvc
+  annotations: {{- .Values.pvc.commonAnnotations | toYaml | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.pvc.accessMode }}
+  {{- if  .Values.pvc.storageClassName }}
   storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.pvc.data.size }}
@@ -26,10 +49,13 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: itop-env-pvc
+  annotations: {{- .Values.pvc.commonAnnotations | toYaml | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.pvc.accessMode }}
+  {{- if  .Values.pvc.storageClassName }}
   storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.pvc.env.size }}
@@ -38,10 +64,30 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: itop-log-pvc
+  annotations: {{- .Values.pvc.commonAnnotations | toYaml | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.pvc.accessMode }}
+  {{- if  .Values.pvc.storageClassName }}
   storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.pvc.log.size }}
+apiVersion: v1
+---
+kind: PersistentVolumeClaim
+metadata:
+  name: itop-extensions-pvc
+  annotations: {{- .Values.pvc.commonAnnotations | toYaml | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.pvc.accessMode }}
+  {{- if  .Values.pvc.storageClassName }}
+  storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.pvc.extensions.size }}
+{{- end }}
+{{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -10,10 +10,11 @@ image:
   tag: 3.0
 
 environment:
-  db_host: <mysql-server-url> "mysql-chart.database.svc.cluster.local"
-  db_name: <mysql-db-name>
-  db_pwd: <mysql-db-pwd>
-  db_user: <mysql-db-user>
+  db_host: itop-mariadb # <address>:<port>
+  db_name: itop_db
+  db_pwd: itop_password
+  db_user: itop_user
+  db_prefix: ""
 
 imagePullSecrets: []
 nameOverride: ""
@@ -32,8 +33,8 @@ container:
   port: 80
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 33
 
 securityContext: {}
   # capabilities:
@@ -44,8 +45,12 @@ securityContext: {}
   # runAsUser: 1000
 
 pvc:
+  enabled: true
+  useOnePV: false
   accessMode: ReadWriteOnce
-  storageClassName: standard
+  storageClassName: ""
+  commonAnnotations:
+    helm.sh/resource-policy: "keep"
   conf:
     size: 1Gi
   data:
@@ -53,6 +58,8 @@ pvc:
   env:
     size: 1Gi
   log:
+    size: 1Gi
+  extensions:
     size: 1Gi
 
 service:
@@ -93,6 +100,19 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+startupProbe:
+  enabled: true
+  failureThreshold: 30
+  periodSeconds: 3
+
+readinessProbe:
+  enabled: true
+  periodSeconds: 3
+
+livenessProbe:
+  enabled: true
+  periodSeconds: 3
+
 autoscaling:
   enabled: false
   minReplicas: 1
@@ -105,3 +125,14 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# setting for mariaDB
+# ( default values: https://github.com/bitnami/charts/blob/main/bitnami/mariadb/values.yaml )
+
+mariadb:
+  enabled: false
+  auth:
+    database: itop_db
+    username: itop_user
+    password: itop_password
+    rootPassword: changeMe


### PR DESCRIPTION
- added mariadb sub chart as dependency to be able deploy maradb in release.

- added startupProbe probe

- added possibility to disable probes for itop deployment, it can be usefull for fresh install process.

- set default value of storageClassName to "" - it is best practice. And will be use default storage type for PV in this case.

- added possibility to use one PV instead of separate PV for each persistence folder.

- added additional PV for extensions folder within documentation of ITOP ver 3

- added install and upgrade notes to README.md